### PR TITLE
feat: minimal multi assets shielded pool impl

### DIFF
--- a/circuits/transaction.circom
+++ b/circuits/transaction.circom
@@ -54,7 +54,7 @@ template Transaction(levels, nIns, nOuts, zeroLeaf) {
     inCheckAsset = ForceEqualIfEnabled();
     inCheckAsset.in[0] <== asset;
     inCheckAsset.in[1] <== publicAsset;
-    inCheckAsset.enabled <-- (publicAsset == 0) ? 0 : 1;
+    inCheckAsset.enabled <== publicAsset; // publicAsset as zero means not enabled
 
     // verify correctness of transaction inputs
     for (var tx = 0; tx < nIns; tx++) {

--- a/contracts/interfaces/IVerifier.sol
+++ b/contracts/interfaces/IVerifier.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.7.0;
 
 interface IVerifier {
-  function verifyProof(bytes memory _proof, uint256[7] memory _input) external view returns (bool);
+  function verifyProof(bytes memory _proof, uint256[8] memory _input) external view returns (bool);
 
-  function verifyProof(bytes memory _proof, uint256[21] memory _input) external view returns (bool);
+  function verifyProof(bytes memory _proof, uint256[22] memory _input) external view returns (bool);
 }

--- a/scripts/compileHasher.js
+++ b/scripts/compileHasher.js
@@ -17,6 +17,7 @@ const contract = {
   contractName: 'Hasher',
   abi: genContract.generateABI(2),
   bytecode: genContract.createCode(2),
+  deployedBytecode: genContract.createCode(2),
 }
 
 fs.writeFileSync(outputFile, JSON.stringify(contract, null, 2))

--- a/src/0_generateAddresses.js
+++ b/src/0_generateAddresses.js
@@ -24,7 +24,6 @@ async function generate(config = defaultConfig) {
         config.verifier16,
         config.MERKLE_TREE_HEIGHT,
         config.hasher,
-        config.gcWeth,
         config.gcOmniBridge,
         config.l1Unwrapper,
         config.govAddress,

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,6 +11,15 @@ const FIELD_SIZE = BigNumber.from(
   '21888242871839275222246405745257275088548364400416034343698204186575808495617',
 )
 
+require('dotenv').config();
+const DEBUG = process.env.DEBUG === 'true';
+
+function debugLog(...args) {
+  if (DEBUG) {
+    console.log(...args);
+  }
+}
+
 /** Generate random number of specified byte length */
 const randomBN = (nbytes = 31) => BigNumber.from(crypto.randomBytes(nbytes))
 
@@ -107,4 +116,5 @@ module.exports = {
   getExtDataHash,
   shuffle,
   getSignerFromAddress,
+  debugLog,
 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -5,7 +5,7 @@ const abi = new ethers.utils.AbiCoder()
 function encodeDataForBridge({ proof, extData }) {
   return abi.encode(
     [
-      'tuple(bytes proof,bytes32 root,bytes32[] inputNullifiers,bytes32[2] outputCommitments,uint256 publicAmount,bytes32 extDataHash)',
+      'tuple(bytes proof,bytes32 root,bytes32[] inputNullifiers,bytes32[2] outputCommitments,uint256 publicAmount,uint256 publicAsset,bytes32 extDataHash)',
       'tuple(address recipient,int256 extAmount,address relayer,uint256 fee,bytes encryptedOutput1,bytes encryptedOutput2,bool isL1Withdrawal,uint256 l1Fee)',
     ],
     [proof, extData],


### PR DESCRIPTION
In this pull request, I've implemented a minimal version of a multi-asset shielded pool based on the latest Nova code. The modifications can be divided into three parts: Circom circuits, smart contracts, and JavaScript test code.

**Circom circuits:**

I've added one public input `publicAsset` and one private input `asset` to the Circom circuits. The `asset` input has been included in the UTXO structure, so it's constrained by the Poseidon hash in both `inCommitmentHasher` and `outCommitmentHasher`. This ensures that the asset type is checked when using a UTXO. To simplify the circuit logic, I've set a constraint that one transaction can only contain one asset type, meaning all UTXOs in a transaction must have the same asset type.

The `publicAsset` input is used for on-chain transfers. Specifically, when `extAmount` is not zero, there will be an on-chain transfer for the token, and the asset type cannot be kept private. In this case, we must ensure that `publicAsset` equals `asset` to maintain security. I've chosen `0` as the default value for `publicAsset`. When `publicAsset` is `0`, no on-chain transfer occurs, and there's no constraint between `publicAsset` and `asset`.

**Smart contracts:**

The smart contracts now support different types of tokens.

**Conclusion:**

I believe that with these modifications, all tokens can share the same privacy level for internal shielded transfers.
