### PR TITLE
Feat: Enhancing Privacy in Swaps with Shielded Pools and External Swap Integration

### DIFF
--- a/circuits/transaction.circom
+++ b/circuits/transaction.circom
@@ -54,7 +54,7 @@ template Transaction(levels, nIns, nOuts, zeroLeaf) {
     inCheckAsset = ForceEqualIfEnabled();
     inCheckAsset.in[0] <== asset;
     inCheckAsset.in[1] <== publicAsset;
-    inCheckAsset.enabled <-- (publicAsset == 0) ? 0 : 1;
+    inCheckAsset.enabled <== publicAsset; // publicAsset as zero means not enabled
 
     // verify correctness of transaction inputs
     for (var tx = 0; tx < nIns; tx++) {

--- a/contracts/SwapExecutor.sol
+++ b/contracts/SwapExecutor.sol
@@ -1,0 +1,53 @@
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "./TornadoPool.sol";
+
+// This contract is used to execute external swap, leading to an arbitrary external call.
+// It should never hold any funds, get any token allowance, or manage any contracts.
+contract SwapExecutor {
+    using SafeERC20 for IERC20;
+
+    function executeSwap(
+        address _tokenIn,
+        address _tokenOut,
+        uint256 _amountIn,
+        uint256 _amountOutMin,
+        address _swapRouter,
+        address _swapRecipient,
+        bytes calldata _swapData,
+        bytes calldata _transactData
+    ) external {
+        // TODO: check msg.sender is TornadoPool to improve security
+        IERC20(_tokenIn).safeApprove(_swapRouter, 0);
+        IERC20(_tokenIn).safeApprove(_swapRouter, _amountIn);
+        {
+            (bool success, ) = _swapRouter.call(_swapData); // deadline limit should be included in _swapData to prevent relayers hold tx for MEV
+            require(success, "SwapExecutor: swap failed");
+        }
+
+        // The transfer can also be done in the swap router directly, but we do it here because we want to enable re-shield feature later.
+        uint256 amountOut = IERC20(_tokenOut).balanceOf(address(this));
+        require(amountOut >= _amountOutMin, "SwapExecutor: received less than expected");
+
+        // if _swapRecipient is zero, we should re-shield the token.
+        // if _swapRecipient is not zero, we should transfer the token to _swapRecipient.
+        if (_swapRecipient == address(0)) {
+            // re-shield token
+            // user should generate proof in advance
+            (TornadoPool.Proof memory _args, TornadoPool.ExtData memory _extData) = abi.decode(
+                _transactData,
+                (TornadoPool.Proof, TornadoPool.ExtData)
+            );
+            IERC20(_tokenOut).safeApprove(msg.sender, 0);
+            IERC20(_tokenOut).safeApprove(msg.sender, _amountOutMin);
+            TornadoPool(msg.sender).transact(_args, _extData);
+            // TODO: there would be some changes in the swap, we transfer it to tx.origin to reward relayer.
+        } else {
+            // transfer token to _swapRecipient
+            IERC20(_tokenOut).safeTransfer(_swapRecipient, amountOut);
+        }
+    }
+}

--- a/contracts/interfaces/ISwapExecutor.sol
+++ b/contracts/interfaces/ISwapExecutor.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.7.0;
+
+interface ISwapExecutor {
+    function executeSwap(
+        address _tokenIn,
+        address _tokenOut,
+        uint256 _amountIn,
+        uint256 _amountOutMin,
+        address _swapRouter,
+        address _swapRecipient,
+        bytes calldata _swapData,
+        bytes calldata _transactData
+    ) external;
+}

--- a/src/0_generateAddresses.js
+++ b/src/0_generateAddresses.js
@@ -29,6 +29,7 @@ async function generate(config = defaultConfig) {
         config.govAddress,
         config.l1ChainId,
         config.gcMultisig,
+        config.swapExecutor,
       ])
       .slice(2)
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,6 +23,13 @@ function debugLog(...args) {
 /** Generate random number of specified byte length */
 const randomBN = (nbytes = 31) => BigNumber.from(crypto.randomBytes(nbytes))
 
+  // address tokenOut;
+  // uint256 amountOutMin;
+  // address swapRecipient;
+  // address swapRouter;
+  // bytes swapData;
+  // bytes transactData;
+
 function getExtDataHash({
   recipient,
   extAmount,
@@ -32,12 +39,18 @@ function getExtDataHash({
   encryptedOutput2,
   isL1Withdrawal,
   l1Fee,
+  tokenOut,
+  amountOutMin,
+  swapRecipient,
+  swapRouter,
+  swapData,
+  transactData,
 }) {
   const abi = new ethers.utils.AbiCoder()
 
   const encodedData = abi.encode(
     [
-      'tuple(address recipient,int256 extAmount,address relayer,uint256 fee,bytes encryptedOutput1,bytes encryptedOutput2,bool isL1Withdrawal,uint256 l1Fee)',
+      'tuple(address recipient,int256 extAmount,address relayer,uint256 fee,bytes encryptedOutput1,bytes encryptedOutput2,bool isL1Withdrawal,uint256 l1Fee,address tokenOut,uint256 amountOutMin,address swapRecipient,address swapRouter,bytes swapData,bytes transactData)',
     ],
     [
       {
@@ -49,9 +62,16 @@ function getExtDataHash({
         encryptedOutput2: encryptedOutput2,
         isL1Withdrawal: isL1Withdrawal,
         l1Fee: l1Fee,
+        tokenOut: toFixedHex(tokenOut, 20),
+        amountOutMin: toFixedHex(amountOutMin),
+        swapRecipient: toFixedHex(swapRecipient, 20),
+        swapRouter: toFixedHex(swapRouter, 20),
+        swapData: swapData,
+        transactData: transactData,
       },
     ],
   )
+  debugLog("getExtDataHash> encodedData", encodedData)
   const hash = ethers.utils.keccak256(encodedData)
   return BigNumber.from(hash).mod(FIELD_SIZE)
 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -6,7 +6,7 @@ function encodeDataForBridge({ proof, extData }) {
   return abi.encode(
     [
       'tuple(bytes proof,bytes32 root,bytes32[] inputNullifiers,bytes32[2] outputCommitments,uint256 publicAmount,uint256 publicAsset,bytes32 extDataHash)',
-      'tuple(address recipient,int256 extAmount,address relayer,uint256 fee,bytes encryptedOutput1,bytes encryptedOutput2,bool isL1Withdrawal,uint256 l1Fee)',
+      'tuple(address recipient,int256 extAmount,address relayer,uint256 fee,bytes encryptedOutput1,bytes encryptedOutput2,bool isL1Withdrawal,uint256 l1Fee,address tokenOut,uint256 amountOutMin,address swapRecipient,address swapRouter,bytes swapData,bytes transactData)',
     ],
     [proof, extData],
   )


### PR DESCRIPTION

Description:

I have developed a new feature called `transactAndSwap` that enhances privacy in DEX swaps by integrating shielded pools with external swap platforms such as Uniswap or 0x. This feature empowers users to conduct swaps while maintaining optimal privacy.

To facilitate this functionality, I introduced a new contract named `SwapExecutor` for managing the execution of external swaps. Additionally, I extended the `ExtData` struct with the following fields:

```diff
  struct ExtData {
    address recipient;
    int256 extAmount;
    address relayer;
    uint256 fee;
    bytes encryptedOutput1;
    bytes encryptedOutput2;
    bool isL1Withdrawal;
    uint256 l1Fee;
+   address tokenOut; // un-shield -> swap via uni or 0x -> re-shield to this token
+   uint256 amountOutMin;
+   address swapRecipient;
+   address swapRouter;
+   bytes swapData;
+   bytes transactData; // used for re-shield
  }
```

To support this feature, I incorporated a new function named `transactAndSwap()`. The workflow consists of the following steps: un-shield (withdraw) tokens to a designated recipient (our `SwapExecutor`), execute the swap using Uniswap or 0x, and, if desired, re-shield the swapped tokens back into the pool. Users can set the `amountOutMin` slightly below the market value to guarantee that a valid proof can be generated beforehand.

The `transactAndSwap` feature accommodates both swap and transfer to a recipient or re-shielding back into the pool. In the latter case, users are required to generate two proofs and forward them to the relayer for processing. The second proof is encoded in the transactData field.

By leveraging `transactAndSwap`, users can capitalize on the best liquidity accessible in the market. Given that on-chain transfers are inevitable, un-shielding the original token first is deemed acceptable. The multi-asset shielded pool allows users to re-shield tokens directly back into the pool without involving their wallets. This approach effectively preserves user privacy, as the identities of both the swapper and swapRecipient remain concealed.
